### PR TITLE
vercel.json 추가

### DIFF
--- a/my-1000days-app/src/pages/Home/Home.jsx
+++ b/my-1000days-app/src/pages/Home/Home.jsx
@@ -9,7 +9,7 @@ import Feed from '../FeedDetail/Feed'; // FeedDetail 컴포넌트 import
 
 import './Home.css';
 
-const LIMIT = 18;
+const LIMIT = 12;
 
 const Home = () => {
   const { user } = useAuth();

--- a/my-1000days-app/vercel.json
+++ b/my-1000days-app/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
React Router 기반 SPA의 URL 처리 방식과 호스팅 설정 문제 발생
- F5 ( 새로고침 ) 시 404 에러 발생
- /home, /map, /upload 같은 라우트는 클라이언트 라우팅.
-사용자가 직접 브라우저 새로고침 (F5) 하면 브라우저는 해당 경로(/map)에 직접 요청을 보냄.
-서버(Vercel, Netlify, Supabase 등)가 이 경로를 모르기 때문에 404 NOT_FOUND 발생.
-✅ 즉, 브라우저는 http://yourapp.com/map에 HTML이 있을 거라 생각하지만,
-실제로는 index.html 하나만 있는 SPA이기 때문에 경로를 못 찾아서 404 발생

해결 방안 

-모든 경로 요청을 index.html로 리다이렉트해서 React Router가 라우팅을 맡게 해줌.

vercel.json 파일 등록

{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}


